### PR TITLE
refactor vnet reference

### DIFF
--- a/environments/dev/applications/data.tf
+++ b/environments/dev/applications/data.tf
@@ -1,6 +1,6 @@
 data "azurerm_client_config" "current" {}
 
-data "azurerm_virtual_network" "vnet-lacc-preprod" {
+data "azurerm_virtual_network" "vnet-lacc" {
   name                = var.vnet_name
   resource_group_name = var.vnet_rg
 }
@@ -9,7 +9,7 @@ data "azurerm_virtual_network" "vnet-lacc-preprod" {
 # To reference a specific subnet use data.azurerm_subnet.base["<subnet-name>"].id
 
 data "azurerm_subnet" "base" {
-  for_each = toset(data.azurerm_virtual_network.vnet-lacc-preprod.subnets)
+  for_each = toset(data.azurerm_virtual_network.vnet-lacc.subnets)
 
   name                 = each.value
   virtual_network_name = var.vnet_name

--- a/environments/dev/base/data.tf
+++ b/environments/dev/base/data.tf
@@ -1,4 +1,4 @@
-data "azurerm_virtual_network" "vnet-lacc-preprod" {
+data "azurerm_virtual_network" "vnet-lacc" {
   name                = var.vnet_name
   resource_group_name = var.vnet_rg
 }

--- a/environments/dev/base/nsg.tf
+++ b/environments/dev/base/nsg.tf
@@ -2,7 +2,7 @@ resource "azurerm_network_security_group" "nsg" {
   count = var.create_nsg ? 1 : 0
 
   name                = "nsg-lacc-${var.subscription_env}"
-  location            = data.azurerm_virtual_network.vnet-lacc-preprod.location
+  location            = data.azurerm_virtual_network.vnet-lacc.location
   resource_group_name = var.vnet_rg
 
   dynamic "security_rule" {

--- a/environments/dev/base/output.tf
+++ b/environments/dev/base/output.tf
@@ -7,5 +7,5 @@ output "subnet_id" {
 
 
 output "virtual_network_id" {
-  value = data.azurerm_virtual_network.vnet-lacc-preprod.id
+  value = data.azurerm_virtual_network.vnet-lacc.id
 }

--- a/environments/dev/base/subnets.tf
+++ b/environments/dev/base/subnets.tf
@@ -2,8 +2,8 @@ resource "azurerm_subnet" "subnets" {
   for_each = var.subnets
 
   name                 = each.key
-  resource_group_name  = data.azurerm_virtual_network.vnet-lacc-preprod.resource_group_name # This must be the resource group that the virtual network resides in
-  virtual_network_name = data.azurerm_virtual_network.vnet-lacc-preprod.name
+  resource_group_name  = data.azurerm_virtual_network.vnet-lacc.resource_group_name # This must be the resource group that the virtual network resides in
+  virtual_network_name = data.azurerm_virtual_network.vnet-lacc.name
   address_prefixes     = each.value.address_prefixes
   service_endpoints    = each.value.service_endpoints
 

--- a/environments/staging/applications/data.tf
+++ b/environments/staging/applications/data.tf
@@ -1,6 +1,6 @@
 data "azurerm_client_config" "current" {}
 
-data "azurerm_virtual_network" "vnet-lacc-preprod" {
+data "azurerm_virtual_network" "vnet-lacc" {
   name                = var.vnet_name
   resource_group_name = var.vnet_rg
 }
@@ -9,7 +9,7 @@ data "azurerm_virtual_network" "vnet-lacc-preprod" {
 # To reference a specific subnet use data.azurerm_subnet.base["<subnet-name>"].id
 
 data "azurerm_subnet" "base" {
-  for_each = toset(data.azurerm_virtual_network.vnet-lacc-preprod.subnets)
+  for_each = toset(data.azurerm_virtual_network.vnet-lacc.subnets)
 
   name                 = each.value
   virtual_network_name = var.vnet_name

--- a/environments/staging/base/data.tf
+++ b/environments/staging/base/data.tf
@@ -1,4 +1,4 @@
-data "azurerm_virtual_network" "vnet-lacc-preprod" {
+data "azurerm_virtual_network" "vnet-lacc" {
   name                = var.vnet_name
   resource_group_name = var.vnet_rg
 }

--- a/environments/staging/base/nsg.tf
+++ b/environments/staging/base/nsg.tf
@@ -2,7 +2,7 @@ resource "azurerm_network_security_group" "nsg" {
   count = var.create_nsg ? 1 : 0
 
   name                = "nsg-lacc-${var.subscription_env}"
-  location            = data.azurerm_virtual_network.vnet-lacc-preprod.location
+  location            = data.azurerm_virtual_network.vnet-lacc.location
   resource_group_name = var.vnet_rg
 
   dynamic "security_rule" {

--- a/environments/staging/base/output.tf
+++ b/environments/staging/base/output.tf
@@ -7,5 +7,5 @@ output "subnet_id" {
 
 
 output "virtual_network_id" {
-  value = data.azurerm_virtual_network.vnet-lacc-preprod.id
+  value = data.azurerm_virtual_network.vnet-lacc.id
 }

--- a/environments/staging/base/subnets.tf
+++ b/environments/staging/base/subnets.tf
@@ -2,8 +2,8 @@ resource "azurerm_subnet" "subnets" {
   for_each = var.subnets
 
   name                 = each.key
-  resource_group_name  = data.azurerm_virtual_network.vnet-lacc-preprod.resource_group_name # This must be the resource group that the virtual network resides in
-  virtual_network_name = data.azurerm_virtual_network.vnet-lacc-preprod.name
+  resource_group_name  = data.azurerm_virtual_network.vnet-lacc.resource_group_name # This must be the resource group that the virtual network resides in
+  virtual_network_name = data.azurerm_virtual_network.vnet-lacc.name
   address_prefixes     = each.value.address_prefixes
   service_endpoints    = each.value.service_endpoints
 


### PR DESCRIPTION
**Code change:** 
Rename the VNet data source from **vnet-lacc-preprod** to **vnet-lacc**. 

**Benefit:**
Removing the environment name from resource names makes the code more easily replicable in prod.

**Infra change:**
The terraform plan for this change shows no changes to actual infrastructure.