### PR TITLE
add 5xx rate and latency alerts for Prod UI SPA

### DIFF
--- a/environments/prod/applications/action-group.tf
+++ b/environments/prod/applications/action-group.tf
@@ -18,6 +18,6 @@ resource "azurerm_monitor_action_group" "ui_alerts" {
   email_receiver {
     name                    = "EmailDevTeam"
     email_address           = var.dev_team_email
-    use_common_alert_schema = false
+    use_common_alert_schema = true
   }
 }

--- a/environments/prod/applications/alerts-api.tf
+++ b/environments/prod/applications/alerts-api.tf
@@ -122,28 +122,3 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "api_exceptions" {
 
   tags = local.tags
 }
-
-resource "azurerm_monitor_metric_alert" "ui_degraded_health" {
-  name                = "alert-lacc-ui-outage-${var.environment}"
-  resource_group_name = azurerm_resource_group.rg.name
-  description         = "The Health Check results for ${azurerm_linux_web_app.ui_spa.name} indicate degraded instance health."
-  scopes              = [azurerm_linux_web_app.ui_spa.id]
-  severity            = 2
-
-  criteria {
-    metric_namespace = "Microsoft.Web/sites"
-    metric_name      = "HealthCheckStatus"
-    aggregation      = "Average"
-    operator         = "LessThan"
-    threshold        = 100
-  }
-
-  frequency   = "PT1M"
-  window_size = "PT5M"
-
-  action {
-    action_group_id = azurerm_monitor_action_group.api_alerts.id
-  }
-
-  tags = local.tags
-}

--- a/environments/prod/applications/alerts-ui.tf
+++ b/environments/prod/applications/alerts-ui.tf
@@ -1,0 +1,75 @@
+resource "azurerm_monitor_metric_alert" "ui_degraded_health" {
+  name                = "alert-lacc-ui-outage-${var.environment}"
+  resource_group_name = azurerm_resource_group.rg.name
+  description         = "The Health Check results for ${azurerm_linux_web_app.ui_spa.name} indicate degraded instance health."
+  scopes              = [azurerm_linux_web_app.ui_spa.id]
+  severity            = 1
+
+  criteria {
+    metric_namespace = "Microsoft.Web/sites"
+    metric_name      = "HealthCheckStatus"
+    aggregation      = "Average"
+    operator         = "LessThanOrEqual"
+    threshold        = 99
+  }
+
+  frequency   = "PT1M"
+  window_size = "PT5M"
+
+  action {
+    action_group_id = azurerm_monitor_action_group.ui_alerts.id
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_monitor_metric_alert" "ui_5xx_rate" {
+  name                = "alert-lacc-ui-5xx-${var.environment}"
+  resource_group_name = azurerm_resource_group.rg.name
+  description         = "A spike in 5xx response rate from ${azurerm_linux_web_app.ui_spa.name}."
+  scopes              = [azurerm_linux_web_app.ui_spa.id]
+  severity            = 2
+
+  criteria {
+    metric_namespace = "Microsoft.Web/sites"
+    metric_name      = "5xx"
+    aggregation      = "Total"
+    operator         = "GreaterThan"
+    threshold        = var.alert_ui_5xx_rate_threshold
+  }
+
+  frequency   = "PT1M"
+  window_size = "PT5M"
+
+  action {
+    action_group_id = azurerm_monitor_action_group.ui_alerts.id
+  }
+
+  tags = local.tags
+}
+
+
+resource "azurerm_monitor_metric_alert" "ui_response_time" {
+  name                = "alert-lacc-ui-response-time-${var.environment}"
+  resource_group_name = azurerm_resource_group.rg.name
+  description         = "A spike in response time from ${azurerm_linux_web_app.ui_spa.name}."
+  scopes              = [azurerm_linux_web_app.ui_spa.id]
+  severity            = 3
+
+  criteria {
+    metric_namespace = "Microsoft.Web/sites"
+    metric_name      = "ResponseTime"
+    aggregation      = "Maximum"
+    operator         = "GreaterThan"
+    threshold        = var.alert_ui_latency_threshold
+  }
+
+  frequency   = "PT1M"
+  window_size = "PT5M"
+
+  action {
+    action_group_id = azurerm_monitor_action_group.ui_alerts.id
+  }
+
+  tags = local.tags
+}

--- a/environments/prod/applications/terraform.tfvars
+++ b/environments/prod/applications/terraform.tfvars
@@ -38,3 +38,6 @@ sa_key_access_enabled = false
 sa_containers = ["lcc-reports-prod", "aspose-templates"]
 
 log_retention_days = 90
+
+alert_ui_5xx_rate_threshold = 1
+alert_ui_latency_threshold  = 15

--- a/environments/prod/applications/variables.tf
+++ b/environments/prod/applications/variables.tf
@@ -152,3 +152,13 @@ variable "dev_team_email" {
   description = "The DL email address of the project's dev team."
   sensitive   = true
 }
+
+variable "alert_ui_5xx_rate_threshold" {
+  type        = number
+  description = "The number of UI SPA 5xx responses over which an alert should be triggered."
+}
+
+variable "alert_ui_latency_threshold" {
+  type        = number
+  description = "The response time in seconds over which a latency alert should be triggered."
+}


### PR DESCRIPTION
Add 2 metric alerts monitoring scope lacc-app-ui-spa-prod:
1. Trigger when 5xx responses exceed 1 over a 5 min lookback period
2. Trigger when maximum response time exceeds 15 seconds over a 5 min lookback period

Move Health Check alert to a new file, update to use UI-specific action group.