### PR TITLE
Task/FCT2-21220 exclude status endpoint from app insights telemetry

### DIFF
--- a/environments/prod/applications/app-insights.tf
+++ b/environments/prod/applications/app-insights.tf
@@ -16,4 +16,5 @@ resource "azurerm_log_analytics_workspace" "law" {
   retention_in_days          = var.log_retention_days
   internet_ingestion_enabled = false
   internet_query_enabled     = false
+  data_collection_rule_id    = azurerm_monitor_data_collection_rule.law_transform.id
 }

--- a/environments/prod/applications/app-insights.tf
+++ b/environments/prod/applications/app-insights.tf
@@ -16,5 +16,7 @@ resource "azurerm_log_analytics_workspace" "law" {
   retention_in_days          = var.log_retention_days
   internet_ingestion_enabled = false
   internet_query_enabled     = false
-  data_collection_rule_id    = azurerm_monitor_data_collection_rule.law_transform.id
+
+  # Not using resource reference to the DCR as this creates a dependency cycle
+  data_collection_rule_id = "${azurerm_resource_group.rg.id}/providers/Microsoft.Insights/dataCollectionRules/dcr-xform-lacc-${var.environment}"
 }

--- a/environments/prod/applications/dcr-log-transform.tf
+++ b/environments/prod/applications/dcr-log-transform.tf
@@ -1,0 +1,40 @@
+resource "azurerm_monitor_data_collection_rule" "law_transform" {
+  name                = "dcr-xform-lacc-${var.environment}"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  kind                = "WorkspaceTransforms"
+
+  destinations {
+    log_analytics {
+      workspace_resource_id = azurerm_log_analytics_workspace.law.id
+      name                  = azurerm_log_analytics_workspace.law.name
+    }
+  }
+
+  # filter out logs for the Status health check endpoint
+  dynamic "data_flow" {
+    for_each = {
+      requests = {
+        streams       = ["Microsoft-Table-AppRequests"]
+        transform_kql = <<-KQL
+          source
+          | where Name != "Status"
+        KQL
+      }
+      traces = {
+        streams       = ["Microsoft-Table-AppTraces"]
+        transform_kql = <<-KQL
+          source
+          | where Properties["Category"] != "Function.Status"
+        KQL
+      }
+    }
+    content {
+      streams       = data_flow.value.streams
+      destinations  = [azurerm_log_analytics_workspace.law.name]
+      transform_kql = data_flow.value.transform_kql
+    }
+  }
+
+  tags = local.tags
+}

--- a/environments/prod/applications/dcr-log-transform.tf
+++ b/environments/prod/applications/dcr-log-transform.tf
@@ -1,13 +1,19 @@
+locals {
+  law_name = "log-analytics-lacc-${var.environment}"
+}
+
 resource "azurerm_monitor_data_collection_rule" "law_transform" {
   name                = "dcr-xform-lacc-${var.environment}"
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
   kind                = "WorkspaceTransforms"
 
+  data_sources {}
+
   destinations {
     log_analytics {
-      workspace_resource_id = azurerm_log_analytics_workspace.law.id
-      name                  = azurerm_log_analytics_workspace.law.name
+      workspace_resource_id = "${azurerm_resource_group.rg.id}/providers/Microsoft.OperationalInsights/workspaces/${local.law_name}"
+      name                  = local.law_name
     }
   }
 
@@ -31,7 +37,7 @@ resource "azurerm_monitor_data_collection_rule" "law_transform" {
     }
     content {
       streams       = data_flow.value.streams
-      destinations  = [azurerm_log_analytics_workspace.law.name]
+      destinations  = [local.law_name]
       transform_kql = data_flow.value.transform_kql
     }
   }

--- a/environments/prod/applications/dcr-log-transform.tf
+++ b/environments/prod/applications/dcr-log-transform.tf
@@ -1,7 +1,3 @@
-locals {
-  law_name = "log-analytics-lacc-${var.environment}"
-}
-
 resource "azurerm_monitor_data_collection_rule" "law_transform" {
   name                = "dcr-xform-lacc-${var.environment}"
   resource_group_name = azurerm_resource_group.rg.name
@@ -12,8 +8,8 @@ resource "azurerm_monitor_data_collection_rule" "law_transform" {
 
   destinations {
     log_analytics {
-      workspace_resource_id = "${azurerm_resource_group.rg.id}/providers/Microsoft.OperationalInsights/workspaces/${local.law_name}"
-      name                  = local.law_name
+      workspace_resource_id = azurerm_log_analytics_workspace.law.id
+      name                  = azurerm_log_analytics_workspace.law.name
     }
   }
 
@@ -37,7 +33,7 @@ resource "azurerm_monitor_data_collection_rule" "law_transform" {
     }
     content {
       streams       = data_flow.value.streams
-      destinations  = [local.law_name]
+      destinations  = [azurerm_log_analytics_workspace.law.name]
       transform_kql = data_flow.value.transform_kql
     }
   }

--- a/environments/staging/applications/app-insights.tf
+++ b/environments/staging/applications/app-insights.tf
@@ -16,4 +16,5 @@ resource "azurerm_log_analytics_workspace" "law" {
   retention_in_days          = var.log_retention_days
   internet_ingestion_enabled = false
   internet_query_enabled     = false
+  data_collection_rule_id    = azurerm_monitor_data_collection_rule.law_transform.id
 }

--- a/environments/staging/applications/app-insights.tf
+++ b/environments/staging/applications/app-insights.tf
@@ -16,5 +16,7 @@ resource "azurerm_log_analytics_workspace" "law" {
   retention_in_days          = var.log_retention_days
   internet_ingestion_enabled = false
   internet_query_enabled     = false
-  data_collection_rule_id    = azurerm_monitor_data_collection_rule.law_transform.id
+
+  # Not using resource reference to the DCR as this creates a dependency cycle
+  data_collection_rule_id = "${azurerm_resource_group.rg.id}/providers/Microsoft.Insights/dataCollectionRules/dcr-xform-lacc-${var.environment}"
 }

--- a/environments/staging/applications/dcr-log-transform.tf
+++ b/environments/staging/applications/dcr-log-transform.tf
@@ -1,0 +1,40 @@
+resource "azurerm_monitor_data_collection_rule" "law_transform" {
+  name                = "dcr-xform-lacc-${var.environment}"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  kind                = "WorkspaceTransforms"
+
+  destinations {
+    log_analytics {
+      workspace_resource_id = azurerm_log_analytics_workspace.law.id
+      name                  = azurerm_log_analytics_workspace.law.name
+    }
+  }
+
+  # filter out logs for the Status health check endpoint
+  dynamic "data_flow" {
+    for_each = {
+      requests = {
+        streams       = ["Microsoft-Table-AppRequests"]
+        transform_kql = <<-KQL
+          source
+          | where Name != \"Status\"
+        KQL
+      }
+      traces = {
+        streams       = ["Microsoft-Table-AppTraces"]
+        transform_kql = <<-KQL
+          source
+          | where Properties[\"Category\"] != \"Function.Status\"
+        KQL
+      }
+    }
+    content {
+      streams       = data_flow.value.streams
+      destinations  = [azurerm_log_analytics_workspace.law.name]
+      transform_kql = data_flow.value.transform_kql
+    }
+  }
+
+  tags = local.tags
+}

--- a/environments/staging/applications/dcr-log-transform.tf
+++ b/environments/staging/applications/dcr-log-transform.tf
@@ -1,13 +1,19 @@
+locals {
+  law_name = "log-analytics-lacc-${var.environment}"
+}
+
 resource "azurerm_monitor_data_collection_rule" "law_transform" {
   name                = "dcr-xform-lacc-${var.environment}"
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
   kind                = "WorkspaceTransforms"
 
+  data_sources {}
+
   destinations {
     log_analytics {
-      workspace_resource_id = azurerm_log_analytics_workspace.law.id
-      name                  = azurerm_log_analytics_workspace.law.name
+      workspace_resource_id = "${azurerm_resource_group.rg.id}/providers/Microsoft.OperationalInsights/workspaces/${local.law_name}"
+      name                  = local.law_name
     }
   }
 
@@ -31,7 +37,7 @@ resource "azurerm_monitor_data_collection_rule" "law_transform" {
     }
     content {
       streams       = data_flow.value.streams
-      destinations  = [azurerm_log_analytics_workspace.law.name]
+      destinations  = [local.law_name]
       transform_kql = data_flow.value.transform_kql
     }
   }

--- a/environments/staging/applications/dcr-log-transform.tf
+++ b/environments/staging/applications/dcr-log-transform.tf
@@ -1,7 +1,3 @@
-locals {
-  law_name = "log-analytics-lacc-${var.environment}"
-}
-
 resource "azurerm_monitor_data_collection_rule" "law_transform" {
   name                = "dcr-xform-lacc-${var.environment}"
   resource_group_name = azurerm_resource_group.rg.name
@@ -12,8 +8,8 @@ resource "azurerm_monitor_data_collection_rule" "law_transform" {
 
   destinations {
     log_analytics {
-      workspace_resource_id = "${azurerm_resource_group.rg.id}/providers/Microsoft.OperationalInsights/workspaces/${local.law_name}"
-      name                  = local.law_name
+      workspace_resource_id = azurerm_log_analytics_workspace.law.id
+      name                  = azurerm_log_analytics_workspace.law.name
     }
   }
 
@@ -37,7 +33,7 @@ resource "azurerm_monitor_data_collection_rule" "law_transform" {
     }
     content {
       streams       = data_flow.value.streams
-      destinations  = [local.law_name]
+      destinations  = [azurerm_log_analytics_workspace.law.name]
       transform_kql = data_flow.value.transform_kql
     }
   }

--- a/environments/staging/applications/dcr-log-transform.tf
+++ b/environments/staging/applications/dcr-log-transform.tf
@@ -18,14 +18,14 @@ resource "azurerm_monitor_data_collection_rule" "law_transform" {
         streams       = ["Microsoft-Table-AppRequests"]
         transform_kql = <<-KQL
           source
-          | where Name != \"Status\"
+          | where Name != "Status"
         KQL
       }
       traces = {
         streams       = ["Microsoft-Table-AppTraces"]
         transform_kql = <<-KQL
           source
-          | where Properties[\"Category\"] != \"Function.Status\"
+          | where Properties["Category"] != "Function.Status"
         KQL
       }
     }


### PR DESCRIPTION
Add log analytics Workspace Transformation DCR (data collection rule).
This removes request and trace logs specifically for the Status endpoint, used for health check.